### PR TITLE
Handle SetForce bug in DART

### DIFF
--- a/plugins/actuator/FMIActuatorPlugin.cc
+++ b/plugins/actuator/FMIActuatorPlugin.cc
@@ -37,12 +37,13 @@ using namespace gazebo_fmi;
 //////////////////////////////////////////////////
 void FMIActuatorPlugin::Load(gazebo::physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 {
-    // Handle Gazebo simbody bug
-    if (gazebo::physics::get_world()->Physics()->GetType() == "simbody")
+    // Handle Gazebo Simbody (  https://bitbucket.org/osrf/gazebo/issues/2507/joint-setforce-is-not-additive-in-simbody )
+    // and DART ( https://bitbucket.org/osrf/gazebo/issues/2526/joint-setforce-is-not-additive-in-dart-in ) bug
+    if (gazebo::physics::get_world()->Physics()->GetType() == "simbody" ||
+        gazebo::physics::get_world()->Physics()->GetType() == "dart")
     {
         this->isSetForceCumulative = false;
     }
-
 
     // Parse parameters
     if (!this->ParseParameters(_parent, _sdf))


### PR DESCRIPTION
DART has a bug similar to the one that affects Simbody, described in https://github.com/robotology/gazebo-fmi/issues/4 . 

Travis does not detect the test failure because Gazebo binaries do not ship by default with DART enabled, but if you locally build a Gazebo with DART enabled, the test were failing. This fixes the tests in that case. 

Gazebo upstream issue: https://bitbucket.org/osrf/gazebo/issues/2526/joint-setforce-is-not-additive-in-dart-in .