### PR TITLE
Fix ComputeJointAcceleration utility function when used with joints attached to "world"

### DIFF
--- a/libraries/private-utils/CMakeLists.txt
+++ b/libraries/private-utils/CMakeLists.txt
@@ -35,4 +35,8 @@ install(TARGETS GazeboFMIPrivateUtils
 set_property(GLOBAL APPEND PROPERTY ${PROJECT_NAME}_TARGETS GazeboFMIPrivateUtils)
 
 
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()
+
 

--- a/libraries/private-utils/include/gazebo_fmi/GazeboFMIUtils.hh
+++ b/libraries/private-utils/include/gazebo_fmi/GazeboFMIUtils.hh
@@ -38,12 +38,12 @@ inline double ComputeJointAcceleration(gazebo::physics::JointPtr jointPtr)
         gazebo::physics::LinkPtr child = jointPtr->GetChild();
 #if GAZEBO_MAJOR_VERSION >=8
         ignition::math::Vector3d A_axis_P_C = jointPtr->GlobalAxis(0u);
-        ignition::math::Vector3d A_domega_A_P = parent->WorldAngularAccel();
-        ignition::math::Vector3d A_domega_A_C = child->WorldAngularAccel();
+        ignition::math::Vector3d A_domega_A_P = parent ? parent->WorldAngularAccel() : ignition::math::Vector3d::Zero;
+        ignition::math::Vector3d A_domega_A_C = child ? child->WorldAngularAccel() : ignition::math::Vector3d::Zero;
 #else
         gazebo::math::Vector3 A_axis_P_C = jointPtr->GetGlobalAxis(0u);
-        gazebo::math::Vector3 A_domega_A_P = parent->GetWorldAngularAccel();
-        gazebo::math::Vector3 A_domega_A_C = child->GetWorldAngularAccel();
+        gazebo::math::Vector3 A_domega_A_P = parent ? parent->GetWorldAngularAccel() : gazebo::math::Vector3::Zero;
+        gazebo::math::Vector3 A_domega_A_C = child ? child->GetWorldAngularAccel() : gazebo::math::Vector3::Zero;
 #endif
         return A_axis_P_C.Dot(A_domega_A_C-A_domega_A_P);
     }

--- a/libraries/private-utils/test/CMakeLists.txt
+++ b/libraries/private-utils/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia
+#
+# Licensed under either the GNU Lesser General Public License v3.0 :
+# https://www.gnu.org/licenses/lgpl-3.0.html
+# or the GNU Lesser General Public License v2.1 :
+# https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+# at your option.
+
+add_executable(GazeboFMIUtilsComputeJointAccelerationTest GazeboFMIUtilsComputeJointAccelerationTest.cc)
+target_include_directories(GazeboFMIUtilsComputeJointAccelerationTest PUBLIC ${GAZEBO_INCLUDE_DIRS})
+find_library(GAZEBO_TEST_LIB NAMES gazebo_test_fixture HINTS ${GAZEBO_LIBRARY_DIRS})
+target_link_libraries(GazeboFMIUtilsComputeJointAccelerationTest PUBLIC ${GAZEBO_LIBRARIES} ${GAZEBO_TEST_LIB} GazeboFMIPrivateUtils gazebo_fmi_gtest)
+target_compile_definitions(GazeboFMIUtilsComputeJointAccelerationTest PRIVATE -DCMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+add_test(NAME GazeboFMIUtilsComputeJointAccelerationTest COMMAND GazeboFMIUtilsComputeJointAccelerationTest)

--- a/libraries/private-utils/test/GazeboFMIUtilsComputeJointAccelerationTest.cc
+++ b/libraries/private-utils/test/GazeboFMIUtilsComputeJointAccelerationTest.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia
+ *
+ * Licensed under either the GNU Lesser General Public License v3.0 :
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ * or the GNU Lesser General Public License v2.1 :
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * at your option.
+ */
+
+#include <gazebo/physics/physics.hh>
+
+#include <gazebo/test/ServerFixture.hh>
+#include <gazebo/test/helper_physics_generator.hh>
+
+#include <gazebo_fmi/GazeboFMIUtils.hh>
+
+class GazeboFMIUtilsComputeJointAccelerationTest : public gazebo::ServerFixture,
+                           public testing::WithParamInterface<const char*>
+{
+  public: void PluginTest(const std::string &_physicsEngine);
+
+  public: void PluginTestHelper(const std::string &_physicsEngine,
+                                const std::string &worldName);
+
+};
+
+void GazeboFMIUtilsComputeJointAccelerationTest::PluginTestHelper(const std::string &_physicsEngine,
+                                             const std::string &worldName)
+{
+  bool worldPaused = true;
+  std::string worldAbsPath = CMAKE_CURRENT_SOURCE_DIR"/" + worldName;
+  Load(worldAbsPath, worldPaused, _physicsEngine);
+
+  gazebo::physics::WorldPtr world = gazebo::physics::get_world("default");
+  ASSERT_TRUE(world != NULL);
+
+  gzdbg << "GazeboFMIUtilsComputeJointAccelerationTest: testing world " << worldName << std::endl;
+
+  // Get model
+#if GAZEBO_MAJOR_VERSION >=8
+  auto model = world->ModelByName("pendulum_attached_to_world");
+#else
+  auto model = world->GetModel("pendulum_attached_to_world");
+#endif
+
+  // Run the world for a few steps
+  for(int i=0; i < 10; i++)
+  {
+    world->Step(1);
+  }
+
+  auto joint = model->GetJoint("upper_joint");
+  double finalJointAcceleration = gazebo_fmi::ComputeJointAcceleration(joint);
+
+  gzdbg << "Final  acceleration " << finalJointAcceleration << std::endl;
+  double tol = 0.1;
+  EXPECT_NEAR(finalJointAcceleration, 0.0, tol);
+
+  // Unload the simulation
+  Unload();
+}
+
+/////////////////////////////////////////////////////////////////////
+void GazeboFMIUtilsComputeJointAccelerationTest::PluginTest(const std::string &_physicsEngine)
+{
+  // We check that the acceleration estimation does not crashes if the "world" link is either parent or child
+  this->PluginTestHelper(_physicsEngine, "test_ComputeJointAcceleration_WorldAsParent.world");
+
+  // Simbody does not support for the world to be a child link
+  if (_physicsEngine != "simbody")
+  {
+    this->PluginTestHelper(_physicsEngine, "test_ComputeJointAcceleration_WorldAsChild.world");
+  }
+}
+
+/////////////////////////////////////////////////
+TEST_P(GazeboFMIUtilsComputeJointAccelerationTest, PluginTest)
+{
+  PluginTest(GetParam());
+}
+
+/////////////////////////////////////////////////
+INSTANTIATE_TEST_CASE_P(PhysicsEngines, GazeboFMIUtilsComputeJointAccelerationTest, PHYSICS_ENGINE_VALUES);
+
+/////////////////////////////////////////////////
+/// Main
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/libraries/private-utils/test/test_ComputeJointAcceleration_WorldAsChild.world
+++ b/libraries/private-utils/test/test_ComputeJointAcceleration_WorldAsChild.world
@@ -1,0 +1,86 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+<world name="default">
+  <include>
+    <uri>model://ground_plane</uri>
+  </include>
+  <include>
+    <uri>model://sun</uri>
+  </include>
+  <model name="pendulum_attached_to_world">
+    <pose>0 -0.5 1.5 0 0 0</pose>
+    <link name="pendulum">
+      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      <inertial>
+        <mass>1.0</mass>
+        <pose>0 0 -1.0 0 0 0</pose>
+        <inertia>
+          <ixx>0.001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.001</iyy>
+          <iyz>0</iyz>
+          <izz>0.001</izz>
+        </inertia>
+      </inertial>
+      <visual name="joint_axis">
+        <pose>0.0 0.0 0.0 1.5707963268 0.0 0.0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.025</radius>
+            <length>0.1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Red</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="rod">
+        <pose>0 0 -0.5 0.0 0.0 0.0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.0185185185185</radius>
+            <length>1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Blue</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="point_mass">
+        <pose>0 0 -1.0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.055555555555555</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Blue</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <joint name="upper_joint" type="revolute">
+      <parent>pendulum</parent>
+      <child>world</child>
+      <axis>
+        <xyz>0.0 1.0 0.0</xyz>
+        <dynamics>
+          <damping>4</damping>
+          <friction>0</friction>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+  </model>
+</world>
+</sdf>

--- a/libraries/private-utils/test/test_ComputeJointAcceleration_WorldAsParent.world
+++ b/libraries/private-utils/test/test_ComputeJointAcceleration_WorldAsParent.world
@@ -1,0 +1,86 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+<world name="default">
+  <include>
+    <uri>model://ground_plane</uri>
+  </include>
+  <include>
+    <uri>model://sun</uri>
+  </include>
+  <model name="pendulum_attached_to_world">
+    <pose>0 -0.5 1.5 0 0 0</pose>
+    <link name="pendulum">
+      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      <inertial>
+        <mass>1.0</mass>
+        <pose>0 0 -1.0 0 0 0</pose>
+        <inertia>
+          <ixx>0.001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.001</iyy>
+          <iyz>0</iyz>
+          <izz>0.001</izz>
+        </inertia>
+      </inertial>
+      <visual name="joint_axis">
+        <pose>0.0 0.0 0.0 1.5707963268 0.0 0.0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.025</radius>
+            <length>0.1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Red</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="rod">
+        <pose>0 0 -0.5 0.0 0.0 0.0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.0185185185185</radius>
+            <length>1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Blue</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="point_mass">
+        <pose>0 0 -1.0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.055555555555555</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Blue</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <joint name="upper_joint" type="revolute">
+      <parent>world</parent>
+      <child>pendulum</child>
+      <axis>
+        <xyz>0.0 1.0 0.0</xyz>
+        <dynamics>
+          <damping>4</damping>
+          <friction>0</friction>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+  </model>
+</world>
+</sdf>


### PR DESCRIPTION
In Gazebo, the "world" link is not a proper link, even if it can  be used in SDF.
For this reason, asking for the API to the "world" link results in a null value.
Before this fix, the plugin that  used the `ComputeJointAcceleration` function were crashing
when attached to a joint attached to the world. With the provided fix, the correct
acceleration for the world (zero) is used. Test have been added to make sure that the problem is
actually fixed.