### PR TITLE
Add damped pendulum example for the actuator plugin 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,13 @@ if(BUILD_TESTING)
     enable_testing()
 endif()
 
+# Enable RPATH support for installed binaries and libraries
+include(AddInstallRPATHSupport)
+add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_FULL_BINDIR}"
+                          LIB_DIRS "${CMAKE_INSTALL_FULL_LIBDIR}"
+                          INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
+                          USE_LINK_PATH)
+
 # Encourage user to specify a build type (e.g. Release, Debug, etc.), otherwise set it to Release.
 if(NOT CMAKE_CONFIGURATION_TYPES)
     if(NOT CMAKE_BUILD_TYPE)
@@ -70,6 +77,11 @@ if(BUILD_TESTING)
   add_subdirectory(extern)
 endif()
 
+# Add setup-examples.sh to easily test exampes
+set(GAZEBO_FMI_EXAMPLES_INSTALL_DIR ${CMAKE_INSTALL_DATAROOTDIR}/gazebo-fmi/examples)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/setup-examples.sh.in ${PROJECT_BINARY_DIR}/setup-examples.sh)
+install(FILES ${PROJECT_BINARY_DIR}/setup-examples.sh DESTINATION ${GAZEBO_FMI_EXAMPLES_INSTALL_DIR})
+
 # Add support libraries
 add_subdirectory(libraries)
 
@@ -84,6 +96,8 @@ install_basic_package_files(${PROJECT_NAME}
                             VARS_PREFIX ${PROJECT_NAME}
                             NO_CHECK_REQUIRED_COMPONENTS_MACRO
                             DEPENDENCIES "gazebo")
+
+
 
 # Add the uninstall target
 include(AddUninstallTarget)

--- a/cmake/setup-examples.sh.in
+++ b/cmake/setup-examples.sh.in
@@ -1,0 +1,11 @@
+# This setup-example.sh file can be source (via the command source <location-of-the-file>/setup-example.sh)
+# to append to the GAZEBO_PLUGIN_PATH the location of the installed gazebo-fmi plugins, and to
+# GAZEBO_RESOURCE_PATH the location of the installed examples .world and .fmu, so that examples
+# world can be launched directly from the terminal, via the command gazebo  <example-world>.word .
+# For more info on Gazebo related env variables, chec http://gazebosim.org/tutorials?tut=components#EnvironmentVariables .
+
+# Load directory that contains the Gazebo plugins
+export GAZEBO_PLUGIN_PATH=$GAZEBO_PLUGIN_PATH:@CMAKE_INSTALL_PREFIX@/lib
+
+# Load directory with example worlds and directory with fmus
+export GAZEBO_RESOURCE_PATH=$GAZEBO_RESOURCE_PATH:@CMAKE_INSTALL_PREFIX@/@GAZEBO_FMI_EXAMPLES_INSTALL_DIR@

--- a/plugins/actuator/CMakeLists.txt
+++ b/plugins/actuator/CMakeLists.txt
@@ -19,6 +19,9 @@ install(TARGETS FMIActuatorPlugin
         RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
 set_property(GLOBAL APPEND PROPERTY ${PROJECT_NAME}_TARGETS FMIActuatorPlugin)
 
+# Build examples FMUs
+add_subdirectory(examples/damped_pendulum)
+
 if(BUILD_TESTING)
     add_subdirectory(test)
 endif()

--- a/plugins/actuator/examples/damped_pendulum/CMakeLists.txt
+++ b/plugins/actuator/examples/damped_pendulum/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia
+#
+# Licensed under either the GNU Lesser General Public License v3.0 :
+# https://www.gnu.org/licenses/lgpl-3.0.html
+# or the GNU Lesser General Public License v2.1 :
+# https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+# at your option.
+
+include(FMIUtils)
+
+# Only create FMU if the OpenModelica compiler (omc) is found in the path
+find_program(OMC_COMPILER NAMES omc)
+
+if(OMC_COMPILER)
+  file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/fmu)
+  omc_compile_mo_to_fmu(INPUT_MO ${CMAKE_CURRENT_SOURCE_DIR}/Damper.mo
+                        MODEL_NAME Damper
+                        OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_custom_target(generate-fmu-damper ALL DEPENDS Damper.fmu)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Damper.fmu DESTINATION ${GAZEBO_FMI_EXAMPLES_INSTALL_DIR})
+endif()
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/Damper.mo DESTINATION ${GAZEBO_FMI_EXAMPLES_INSTALL_DIR})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/damped_pendulum.world DESTINATION ${GAZEBO_FMI_EXAMPLES_INSTALL_DIR})
+

--- a/plugins/actuator/examples/damped_pendulum/Damper.mo
+++ b/plugins/actuator/examples/damped_pendulum/Damper.mo
@@ -1,0 +1,37 @@
+model Damper
+  Modelica.Blocks.Interfaces.RealInput actuatorInput annotation(
+    Placement(visible = true, transformation(origin = {-120, 0}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-120, 0}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput jointPosition annotation(
+    Placement(visible = true, transformation(origin = {120, -60}, extent = {{-20, -20}, {20, 20}}, rotation = 180), iconTransformation(origin = {120, -60}, extent = {{-20, -20}, {20, 20}}, rotation = 180)));
+  Modelica.Blocks.Interfaces.RealInput jointVelocity annotation(
+    Placement(visible = true, transformation(origin = {120, -20}, extent = {{-20, -20}, {20, 20}}, rotation = 180), iconTransformation(origin = {120, -20}, extent = {{-20, -20}, {20, 20}}, rotation = 180)));
+  Modelica.Blocks.Interfaces.RealOutput jointTorque annotation(
+    Placement(visible = true, transformation(origin = {110, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {110, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Mechanics.Rotational.Components.AngleToTorqueAdaptor angleToTorqueAdaptor1(use_a = true, use_w = true)  annotation(
+    Placement(visible = true, transformation(origin = {31, 0}, extent = {{-21, -20}, {21, 20}}, rotation = 180)));
+  Modelica.Blocks.Math.Gain invertSign(k = -1)  annotation(
+    Placement(visible = true, transformation(origin = {62, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput jointAcceleration annotation(
+    Placement(visible = true, transformation(origin = {120, 20}, extent = {{-20, -20}, {20, 20}}, rotation = 180), iconTransformation(origin = {120, 20}, extent = {{-20, -20}, {20, 20}}, rotation = 180)));
+  Modelica.Mechanics.Rotational.Components.Damper damper1(d = 0.1)  annotation(
+    Placement(visible = true, transformation(origin = {-20, 3.55271e-15}, extent = {{-20, -20}, {20, 20}}, rotation = 180)));
+  Modelica.Mechanics.Rotational.Components.Fixed fixed1 annotation(
+    Placement(visible = true, transformation(origin = {-72, 3.55271e-15}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+equation
+  connect(damper1.flange_b, fixed1.flange) annotation(
+    Line(points = {{-40, 0}, {-72, 0}}));
+  connect(damper1.flange_a, angleToTorqueAdaptor1.flange) annotation(
+    Line(points = {{0, 0}, {26, 0}}));
+  connect(angleToTorqueAdaptor1.tau, invertSign.u) annotation(
+    Line(points = {{37, 16}, {42, 16}, {42, 60}, {50, 60}}, color = {0, 0, 127}));
+  connect(jointPosition, angleToTorqueAdaptor1.phi) annotation(
+    Line(points = {{120, -60}, {70.5, -60}, {70.5, -16}, {39, -16}}, color = {0, 0, 127}));
+  connect(jointVelocity, angleToTorqueAdaptor1.w) annotation(
+    Line(points = {{120, -20}, {76.5, -20}, {76.5, -6}, {39, -6}}, color = {0, 0, 127}));
+  connect(jointAcceleration, angleToTorqueAdaptor1.a) annotation(
+    Line(points = {{120, 20}, {60, 20}, {60, 6}, {39, 6}}, color = {0, 0, 127}));
+  connect(invertSign.y, jointTorque) annotation(
+    Line(points = {{73, 60}, {110, 60}}, color = {0, 0, 127}));
+  annotation(
+    uses(Modelica(version = "3.2.2")));
+end Damper;

--- a/plugins/actuator/examples/damped_pendulum/README.md
+++ b/plugins/actuator/examples/damped_pendulum/README.md
@@ -1,0 +1,20 @@
+# Damped Pendulum example
+This directory contains a simple Gazebo world, that contains two damped pendulum models.
+The models are identical, with the difference that in one the damping effect is computed
+via the Gazebo's physics engine setting the `damping` SDF tag, while for the other the damping
+is computed via the Modelica model `Damper.mo`.
+
+## How to run
+First  of all, make sure that you have `omc` (the OpenModelica compiler) in your PATH, otherwise
+it will not be possible for the build system to generate an FMU from the `Damper.fmu` model.
+After that, compile and install the `gazebo-fmi` project and source the `<install_prefix>/share/gazebo-fmi/examples/setup-examples.sh` bash script, where <install_prefix> is
+your installation directory (the value of `CMAKE_INSTALL_PREFIX`).
+
+At this point, you can launch the simulation of the damped pendulum using the following command:
+~~~
+gazebo -u -e simbody damped_pendulum.world
+~~~
+the `-u` option ensures that the simulation start paused, while the `-e simbody` that the simulation
+is performed with simbody, the most accurate of the physics engine available by default in Gazebo.
+If you play the simulation, you will  see how the movements of the two pendulum will be synchronized, even
+if one is simulating the damping via the Gazebo's physics engine, and one via the damping model contained  in `Damper.mo`.

--- a/plugins/actuator/examples/damped_pendulum/damped_pendulum.world
+++ b/plugins/actuator/examples/damped_pendulum/damped_pendulum.world
@@ -1,0 +1,175 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+<world name="default">
+  <include>
+    <uri>model://ground_plane</uri>
+  </include>
+  <include>
+    <uri>model://sun</uri>
+  </include>
+
+  <!-- Damped pendulum model in which the damping is computed by the physics engine via the damping specified in SDF tags -->
+  <model name="pendulum_damped_via_sdf">
+    <pose>0 -0.5 1.5 0 0 0</pose>
+    <link name="pendulum">
+      <pose>0.0 0.0 0.0 0.0 1.5707963268 0.0</pose>
+      <inertial>
+        <mass>1.0</mass>
+        <pose>0 0 -1.0 0 0 0</pose>
+        <inertia>
+          <ixx>0.001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.001</iyy>
+          <iyz>0</iyz>
+          <izz>0.001</izz>
+        </inertia>
+      </inertial>
+      <visual name="joint_axis">
+        <pose>0.0 0.0 0.0 1.5707963268 0.0 0.0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.025</radius>
+            <length>0.1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Red</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="rod">
+        <pose>0 0 -0.5 0.0 0.0 0.0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.0185185185185</radius>
+            <length>1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Blue</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="point_mass">
+        <pose>0 0 -1.0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.055555555555555</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Blue</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <joint name="joint" type="revolute">
+      <parent>world</parent>
+      <child>pendulum</child>
+      <axis>
+        <xyz>0.0 1.0 0.0</xyz>
+        <dynamics>
+          <damping>0.1</damping>
+          <friction>0</friction>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+  </model>
+
+  <!-- Damped pendulum model in which the damping is computed via a damper Modelica model, loaded via gazebo_fmi  -->
+  <model name="pendulum_damped_via_fmi">
+    <pose>0 0.5 1.5 0 0 0</pose>
+    <link name="pendulum">
+      <pose>0.0 0.0 0.0 0.0 1.5707963268 0.0</pose>
+      <inertial>
+        <mass>1.0</mass>
+        <pose>0 0 -1.0 0 0 0</pose>
+        <inertia>
+          <ixx>0.001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.001</iyy>
+          <iyz>0</iyz>
+          <izz>0.001</izz>
+        </inertia>
+      </inertial>
+      <visual name="joint_axis">
+        <pose>0.0 0.0 0.0 1.5707963268 0.0 0.0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.025</radius>
+            <length>0.1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Red</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="rod">
+        <pose>0 0 -0.5 0.0 0.0 0.0</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.0185185185185</radius>
+            <length>1</length>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Blue</name>
+          </script>
+        </material>
+      </visual>
+      <visual name="point_mass">
+        <pose>0 0 -1.0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.055555555555555</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Blue</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <joint name="joint" type="revolute">
+      <parent>world</parent>
+      <child>pendulum</child>
+      <axis>
+        <xyz>0.0 1.0 0.0</xyz>
+        <dynamics>
+          <!-- For this model the damping is 0 as the damping action will be provided by the damper fmu -->
+          <damping>0.0</damping>
+          <friction>0.0</friction>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
+    <!-- fmi actuator plugin -->
+    <plugin name="damper" filename="libFMIActuatorPlugin.so">
+       <actuator>
+         <name>upper_joint_actuator</name>
+         <joint>joint</joint>
+         <fmu>Damper.fmu</fmu>
+       </actuator>
+    </plugin>
+  </model>
+</world>
+</sdf>
+


### PR DESCRIPTION
Also add a simple installation pattern to enable users to quickly test the examples. It would be probably worthy if the README was update to link directly to the examples, but this will be done in separate PR refreshing the README at all.