### PR TITLE
Fix order of Gazebo test library and rest of Gazebo libraries

### DIFF
--- a/plugins/actuator/test/CMakeLists.txt
+++ b/plugins/actuator/test/CMakeLists.txt
@@ -30,7 +30,7 @@ omc_compile_mo_to_fmu(INPUT_MO ${CMAKE_CURRENT_SOURCE_DIR}/DelayTransmission.mo
 add_executable(FMIActuatorPluginPositionRegulationTest FMIActuatorPluginPositionRegulationTest.cc)
 target_include_directories(FMIActuatorPluginPositionRegulationTest PUBLIC ${GAZEBO_INCLUDE_DIRS})
 find_library(GAZEBO_TEST_LIB NAMES  gazebo_test_fixture HINTS ${GAZEBO_LIBRARY_DIRS})
-target_link_libraries(FMIActuatorPluginPositionRegulationTest PUBLIC ${GAZEBO_LIBRARIES} ${GAZEBO_TEST_LIB} gazebo_fmi_gtest)
+target_link_libraries(FMIActuatorPluginPositionRegulationTest PUBLIC ${GAZEBO_TEST_LIB} ${GAZEBO_LIBRARIES} gazebo_fmi_gtest)
 target_compile_definitions(FMIActuatorPluginPositionRegulationTest PRIVATE -DCMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 target_compile_definitions(FMIActuatorPluginPositionRegulationTest PRIVATE -DCMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 target_compile_definitions(FMIActuatorPluginPositionRegulationTest PRIVATE -DFMI_ACTUATOR_PLUGIN_BUILD_DIR="$<TARGET_FILE_DIR:FMIActuatorPlugin>")

--- a/plugins/single-body-fluid-dynamics/test/CMakeLists.txt
+++ b/plugins/single-body-fluid-dynamics/test/CMakeLists.txt
@@ -19,7 +19,7 @@ omc_compile_mo_to_fmu(INPUT_MO ${CMAKE_CURRENT_SOURCE_DIR}/NullFriction.mo
 add_executable(FMISingleBodyFluidDynamicsPluginTest FMISingleBodyFluidDynamicsPluginTest.cc)
 target_include_directories(FMISingleBodyFluidDynamicsPluginTest PUBLIC ${GAZEBO_INCLUDE_DIRS})
 find_library(GAZEBO_TEST_LIB NAMES  gazebo_test_fixture HINTS ${GAZEBO_LIBRARY_DIRS})
-target_link_libraries(FMISingleBodyFluidDynamicsPluginTest PUBLIC ${GAZEBO_LIBRARIES} ${GAZEBO_TEST_LIB} gazebo_fmi_gtest)
+target_link_libraries(FMISingleBodyFluidDynamicsPluginTest PUBLIC ${GAZEBO_TEST_LIB} ${GAZEBO_LIBRARIES} gazebo_fmi_gtest)
 target_compile_definitions(FMISingleBodyFluidDynamicsPluginTest PRIVATE -DCMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 target_compile_definitions(FMISingleBodyFluidDynamicsPluginTest PRIVATE -DCMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 target_compile_definitions(FMISingleBodyFluidDynamicsPluginTest PRIVATE -DFMI_PLUGIN_BUILD_DIR="$<TARGET_FILE_DIR:FMISingleBodyFluidDynamicsPlugin>")


### PR DESCRIPTION
The `gazebo_test_fixture` is a static library, and when linking an executable the order of static libraries can be relevant (see for example https://github.com/ignitionrobotics/ign-msgs/commit/f0c9ff727ef3ae5241f9088f907c17faea132c56). Without this fix, on Ubuntu 20.04/Gazebo 11 the compilation was failing with:
~~~
[ 73%] Linking CXX executable ../../../bin/FMIActuatorPluginPositionRegulationTest
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libgazebo_sensors.so: undefined reference to symbol '_ZTVN5boost6detail16thread_data_baseE'
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.71.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [plugins/actuator/test/CMakeFiles/FMIActuatorPluginPositionRegulationTest.dir/build.make:138: bin/FMIActuatorPluginPositionRegulationTest] Error 1
make[1]: *** [CMakeFiles/Makefile2:499: plugins/actuator/test/CMakeFiles/FMIActuatorPluginPositionRegulationTest.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
~~~ 

Fix https://github.com/robotology/gazebo-fmi/issues/71 .